### PR TITLE
Reproduction case for our forceDelete bug and proposed fix

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 down=false
-php="8.0"
+php="8.1"
 
 while true; do
   case "$1" in

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1182,13 +1182,14 @@ class Builder implements BuilderContract
     /**
      * Run the default delete function on the builder.
      *
-     * Since we do not apply scopes here, the row will actually be deleted.
+     * Unlike `delete` this does not use onDelete behavior, so traits that `extend` Builder
+     * (like SoftDeletingScope) can't intercept the DELETE and turn it into an UPDATE.
      *
      * @return mixed
      */
     public function forceDelete()
     {
-        return $this->query->delete();
+        return $this->toBase()->delete();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/MassPrunable.php
+++ b/src/Illuminate/Database/Eloquent/MassPrunable.php
@@ -15,16 +15,21 @@ trait MassPrunable
      */
     public function pruneAll(int $chunkSize = 1000)
     {
+        $usesSoftDeletes = in_array(SoftDeletes::class, class_uses_recursive(get_class($this)));
         $query = tap($this->prunable(), function ($query) use ($chunkSize) {
             $query->when(! $query->getQuery()->limit, function ($query) use ($chunkSize) {
                 $query->limit($chunkSize);
             });
         });
 
+        if ($usesSoftDeletes) {
+            $query->withTrashed();
+        }
+
         $total = 0;
 
         do {
-            $total += $count = in_array(SoftDeletes::class, class_uses_recursive(get_class($this)))
+            $total += $count = $usesSoftDeletes
                         ? $query->forceDelete()
                         : $query->delete();
 


### PR DESCRIPTION
The root issue is that if you prepare an Eloquent query that uses global scopes, the results you get with `count` or `get` are not the same as the things that will be deleted by `forceDelete`.  

We had a production incident where we carefully prepared a query in Tinker, `get` and `count` were spot on, but when we ran `forceDelete` it affected 13000 more rows, destroying data for hundreds of accounts who have paused service.

Comments in `\Illuminate\Database\Eloquent\Builder::forceDelete` suggest it needs to ignore global scopes to work with soft deletes, but that's not supported by the unit tests. As long as it avoids the `onDelete` behavior that turns DELETE sql into UPDATE sql, then all existing Eloquent unit tests pass unmodified.

(The 2014 comment on `Builder::forceDelete` seemed to assume the only global scope is Soft Deletes, but we encountered this bug in the way `nanigans/single-table-inheritance` uses global scopes, and the unit test is based on the [simple documentation case for all global scopes](https://laravel.com/docs/9.x/eloquent#applying-global-scopes).)

The weird side effect of this change is that MassPrunable was documented and unit tested to affect soft deleted records, _even if soft delete scopes weren't specified in the user's pruneable query_.  My approach in this PR was to preserve that behavior, but I _personally_ think the change introduced on lines 25-28 should be removed in a future version of Laravel (at a time when semver says we can introduce breaking behavior changes) and docs should be updated that `pruneable` needs to manage `withTrashed` or `onlyTrashed` at the author's discretion.